### PR TITLE
Update instructions and run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,45 @@ Mozilla perfomance alerts manager
 
 3. Install docker-compose by following the instructions on [this page][docker-compose]
 
-3. Run the following git clone (specify a directory of your choosing if you like):
+4. Run the following git clone (specify a directory of your choosing if you like):
 
         git clone https://github.com/mishravikas/perfmanager.git
 
-4. cd into the name of the directory into which you cloned the git repository
+5. cd into the name of the directory into which you cloned the git repository
 
         cd perfmanager
 
-5. Run virtualenv on the git cloned directory to setup the Python virtual environment:
+6. Run virtualenv on the git cloned directory to setup the Python virtual environment:
 
         virtualenv venv
 
-6. Activate the virtual environment:
+7. Activate the virtual environment:
 
         source venv/bin/activate
 
-7. Run docker-compose to set up the environment:
+8. Run docker-compose to set up the environment:
 
-        cd dockerfiles; docker-compose up --no-recreate
+        docker-compose -f dockerfiles/docker-compose.yml up --no-recreate
 
-8. Visit [http://localhost:8080/][localhost] in your browser once you see `Starting Server` on the console.
+9. On first run, run migrations and load initial data
+
+        docker exec $(docker-compose -f dockerfiles/docker-compose.yml ps -q web) python /srv/www/perfmanager/manage.py migrate
+        docker exec $(docker-compose -f dockerfiles/docker-compose.yml ps -q web) python /srv/www/perfmanager/manage.py loaddata /srv/www/perfmanager/initial_data.json
+
+10. Visit [http://localhost:8080/][localhost] in your browser once you see `Starting Server` on the console. Press Ctrl-C on the console to stop the containers
+
+11. Henceforth, use `docker-compose -f dockerfiles/docker-compose.yml up --no-recreate` to restart the containers.
 
 [docker]: https://docs.docker.com/installation/
 [docker-compose]: http://docs.docker.com/compose/install/
 [localhost]: http://localhost:8080
+
+###Executing commands on running containers
+
+Until docker-compose [issue #593][issue-593] is resolved, please use the following syntax to run commands on the web service
+
+        docker exec $(docker-compose -f dockerfiles/docker-compose.yml ps -q web) <COMMAND>
+
+For example, refer to point 9 above for running migrations and loading initial data on first run.
+
+[issue-593]: https://github.com/docker/compose/issues/593

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -5,11 +5,10 @@ database:
 
 web:
     build: ./perfmanager_web
-    command: /bin/bash /srv/www/perfmanager/run.sh
     links:
       - database:database
     volumes:
-      - ..:/srv/www/perfmanager
+      - .:/srv/www/perfmanager
     ports:
       - "8000:8000"
 

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,8 @@
 #! /bin/bash
 
-# Hack to wait for db to be up and running
-sleep 10
-
-python /srv/www/perfmanager/manage.py migrate
-
-python /srv/www/perfmanager/manage.py loaddata /srv/www/perfmanager/initial_data.json
+# Hack to wait for db to be up and running - to be removed when
+# docker-compose issue #374 is resolved
+sleep 15
 
 echo "Starting Server"
 


### PR DESCRIPTION
Updated run.sh to not load initial_data.json every time during docker-compose up.

Added instructions for executing commands on running containers - used when running migrations and loading initial data
